### PR TITLE
Chore: fix Card & Card CardCarousel console errors; add key to map

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -35,9 +35,7 @@ export const Card = ({
           >
             <path
               stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
+        
               d="M1 5h12m0 0L9 1m4 4L9 9"
             />
           </svg>

--- a/src/components/CardCarousel.tsx
+++ b/src/components/CardCarousel.tsx
@@ -24,7 +24,7 @@ export default function CardCarousel() {
       <div className="overflow-hidden relative">
           <div className="flex transition ease-out duration-700" style={{ transform: `translateX(-${currentCard * 33}%)` }}>
                {cardRefs.map((card, index) => (
-                     <Card id={index} title={card.title} description={card.description} imgsrc={card.imgsrc} link={card.link} />
+                     <Card id={index} key={index} title={card.title} description={card.description} imgsrc={card.imgsrc} link={card.link} />
                ))}
                </div>
           </div>


### PR DESCRIPTION
I did this by removing the stroke lines since they werent doing anything. Also added a key to the mapping.