### PR TITLE
Game: Adjusted various element styles in the in-game UI

### DIFF
--- a/src/game/scenes/CardShop.ts
+++ b/src/game/scenes/CardShop.ts
@@ -36,12 +36,12 @@ export class CardShop extends Scene
         this.shopBell.play();
         //set-up shop background and close button 
         this.shopBackground = this.add.image(512, 450, 'cardshopbackground').setScale(1.5);
-        let xButton = this.add.text(270, 160, 'x', {color: "000000", fontSize: 30, fontFamily: 'Arial Black' }).setInteractive().setOrigin(0);
+        let xButton = this.add.text(282, 180, 'X', {color: "#ff0000", fontSize: 55, fontFamily: 'Arial Black' }).setInteractive().setOrigin(0);
         xButton.on('pointerover', () => {
             xButton.setStyle({color: '#FFFFFF'} );
         })
         .on('pointerout', () => {
-            xButton.setStyle({color: "000000" });
+            xButton.setStyle({color: "#ff0000" });
         });
         xButton.on('pointerdown', () => {
             this.scene.setVisible(false);
@@ -59,8 +59,9 @@ export class CardShop extends Scene
    
 
         this.cardText = this.add.text(380, 400, '', {color: "000000", fontSize: 30, fontFamily: 'Arial Black'});
-        this.errorText = this.add.text(430, 550, '', {color: "000000", fontSize: 20, fontFamily: 'Arial Black'});
-        this.add.text(410, 660, '70% green 20% blue 9.5% yellow 0.5% red', {color: "000000", fontSize: 10, fontFamily: 'Arial Black'});
+        this.errorText = this.add.text(370, 550, 'Click below to purchase a card!', {color: "#00ff26", fontSize: 20, fontFamily: 'Arial Black'});
+        this.add.text(400, 670, 'CARD DROP RATES:', {color: "#00d0ff", fontSize: 25, fontFamily: 'Arial Black'}).setColor("blue");
+        this.add.text(220, 710, '70% Green, 20% Blue, 9.5% Yellow, 0.5% Red', {color: "#aa38fc", fontSize: 25, fontFamily: 'Arial Black'});
         //exhange coins for cards
         this.purchaseButton = this.add.image(530, 620 ,'buyicon' ).setInteractive().setScale(0.1);
         this.purchaseButton
@@ -183,8 +184,8 @@ export class CardShop extends Scene
             this.scene.sendToBack();
         };
 
-        if (this.currentCoins < 200) this.errorText.setText('not enough coins!');
-        else this.errorText.setText('');
+        if (this.currentCoins < 200) this.errorText.setText('Not enough coins!').setColor("#c20000");
+        else this.errorText.setText('Click below to purchase a card!');
     }
     randomCardChooser()
     {

--- a/src/game/scenes/CardShop.ts
+++ b/src/game/scenes/CardShop.ts
@@ -59,7 +59,7 @@ export class CardShop extends Scene
    
 
         this.cardText = this.add.text(380, 400, '', {color: "000000", fontSize: 30, fontFamily: 'Arial Black'});
-        this.errorText = this.add.text(370, 550, 'Click below to purchase a card!', {color: "#00ff26", fontSize: 20, fontFamily: 'Arial Black'});
+        this.errorText = this.add.text(370, 550, '', {color: "#00ff26", fontSize: 20, fontFamily: 'Arial Black'});
         this.add.text(400, 670, 'CARD DROP RATES:', {color: "#00d0ff", fontSize: 25, fontFamily: 'Arial Black'}).setColor("blue");
         this.add.text(220, 710, '70% Green, 20% Blue, 9.5% Yellow, 0.5% Red', {color: "#aa38fc", fontSize: 25, fontFamily: 'Arial Black'});
         //exhange coins for cards

--- a/src/game/scenes/Exchange.ts
+++ b/src/game/scenes/Exchange.ts
@@ -70,7 +70,7 @@ export class Exchange extends Scene
         //conversion text
         this.mushroomIcon = this.add.image(330, 300, 'mushroom4').setScale(0.4);
         this.shopText = this.add.text(380, 290, '', {color: "000000", fontSize: 30, fontFamily: 'Arial Black'});
-        this.add.image(570, 310, 'coin').setScale(0.05);
+        this.add.image(530, 310, 'coin').setScale(0.05);
 
         //display how many mushrooms user has and their offer
         this.youHaveText = this.add.text(450, 240, '', {color: "000000", fontSize: 20, fontFamily: 'Arial Black'});
@@ -132,7 +132,7 @@ export class Exchange extends Scene
     {   
         this.secondsLeft = this.mushroomExchangeRateTimer.getRemainingSeconds().toString().substring(0, 3);
         this.todayRateText.setText(`Price time left: ${this.secondsLeft}`);
-        this.shopText.setText(`x ${this.numberInputValue}     =             x ${this.todayRate * this.numberInputValue}`);
+        this.shopText.setText(`x ${this.numberInputValue} =          x ${this.todayRate * this.numberInputValue}`);
         this.youHaveText.setText(`you have        x ${this.currentMushrooms}`);
         this.userMushroomOffer.setText(`        x1 =     x${this.todayRate}`);
 

--- a/src/game/scenes/Game.ts
+++ b/src/game/scenes/Game.ts
@@ -278,7 +278,7 @@ export class Game extends Scene
         this.tutorialTextBox = this.createTextBox();
         
         this.cameras.main.once(Phaser.Cameras.Scene2D.Events.FADE_IN_COMPLETE, () => {
-            if(!this.userFinishTutorial)this.tutorialTextBox.start('プライドファームのきのこ小屋へようこそ！\f\nここでは、水やり、手入れ、収穫など、自分だけのシイタケを作ることができます！\f\nまずは丸太に水をやりましょう！\f\n画面をクリックすると、水やりが開始されます。', 20);
+            if(!this.userFinishTutorial)this.tutorialTextBox.start('Welcome to the Pride Farm mushroom shed!\f\nHere you will be responsible to water, take care of, and harvest your very own Shiitake mushrooms!\f\nLets first water the log!\f\nClick anywhere on the screen to start watering the log.', 20);
             else {
                 this.isTextDone = true;
                 this.hasRun = true;
@@ -422,7 +422,7 @@ export class Game extends Scene
         const harvestText = this.createTextBox();
         
         this.time.delayedCall(2000, () => {
-            if(!this.mushroomGroup && !this.userFinishTutorial) harvestText.start('よくやったわ！\f\nキノコを収穫するためには、キノコが成長するのを待たなければなりません。\f\nタイマーが切れるのを待ちましょう。\f\nタイマーが終わったら、クリックしてキノコを収穫しましょう。', 20);
+            if(!this.mushroomGroup && !this.userFinishTutorial) harvestText.start('Nice work!\f\nNow we must wait for our mushrooms to grow in order to harvest them.\f\nIn the top left corner, there is a timer that will tell you when the mushrooms are finished growing.\f\nOnce that is over, click on the mushrooms to harvest them!\f\nAfterwards, you may water the log again and harvest as many mushrooms as you would like!\f\nThen, using the two shop icons in the top right, you can purchase coins and cool collectors cards!\f\nHappy harvesting!', 20);
             // English:
             // Nice work! Now we must wait for our mushrooms to grow in order to harvest them. Lets wait for the timer to go down. And once that is over, click to harvest the mushrooms
             if(this.isTextDone === true || this.mushroomGroup){
@@ -465,7 +465,7 @@ export class Game extends Scene
 
         //make mushrooms draggable
         this.input.on('dragstart', (_pointer: PointerEvent, gameObject: Phaser.Physics.Arcade.Sprite) => {
-            gameObject.setTint(0xff0000)
+            gameObject.setTint(0x00ffa6)
         });
 
         this.input.on('drag', (_pointer: PointerEvent, gameObject: Phaser.Physics.Arcade.Sprite , dragX: number, dragY: number) => {

--- a/src/game/scenes/Inventory.ts
+++ b/src/game/scenes/Inventory.ts
@@ -37,12 +37,12 @@ export class Inventory extends Scene
         this.userInventory = data.userInventory;
 
         this.background = this.add.image(512, 400, 'inventoryBackground').setScale(1.8).setAlpha(1)
-        let xButton = this.add.text(110, 90, 'x', {color: "000000", fontSize: 30, fontFamily: 'Arial Black' }).setInteractive().setOrigin(0);
+        let xButton = this.add.text(110, 90, 'X', {color: "#ff0000", fontSize: 45, fontFamily: 'Arial Black' }).setInteractive().setOrigin(0);
         xButton.on('pointerover', () => {
             xButton.setStyle({color: '#FFFFFF'} );
         })
         .on('pointerout', () => {
-            xButton.setStyle({color: "000000" });
+            xButton.setStyle({color: "#ff0000" });
         });
         xButton.on('pointerdown', () => {
             this.scene.setVisible(false);
@@ -50,7 +50,7 @@ export class Inventory extends Scene
             this.scene.resume('Game');
         });
 
-        this.sellText = this.add.text(100, 680, '', {color: "000000", fontSize: 20, fontFamily: 'Arial Black'}).setVisible(false)
+        this.sellText = this.add.text(85, 600, '', {color: "#1900ff", fontSize: 20, fontFamily: 'Arial Black'}).setVisible(false)
         .setInteractive().on('pointerdown', () => {
             this.sellSound.play();
             let cardRarity = this.userInventory[this.selectedCardToSell!].slice(0,3);
@@ -171,13 +171,13 @@ export class Inventory extends Scene
                     this.sellText.setVisible(true);
                     this.selectedCardToSell = this.userInventory.indexOf(card);
                     if(currentCard.texture.key.slice(0,3) === 'gre') {
-                        this.sellText.setText('Sell for 10 Coin')
+                        this.sellText.setText('SELL FOR 10 COINS')
                     } else if(currentCard.texture.key.slice(0,3) === 'blu') {
-                        this.sellText.setText('Sell for 20 Coin')
+                        this.sellText.setText('SELL FOR 20 COINS')
                     } else if(currentCard.texture.key.slice(0,3) === 'yel') {
-                        this.sellText.setText('Sell for 40 Coin')
+                        this.sellText.setText('SELL FOR 40 COINS')
                     } else if(currentCard.texture.key.slice(0,3) === 'red') {
-                        this.sellText.setText('Sell for 50 Coin')
+                        this.sellText.setText('SELL FOR 50 COINS')
                     }
                 } else {
                     // currentCard.setScale(0.1).setPosition(ownX, ownY).setDepth(0);


### PR DESCRIPTION
Change log:

- Changed tutorial text back to English for the sake of consistency with the rest of the predominantly English localization of the game's content
- Added more information to the latter part of the tutorial text box to inform the user of the roles the exchange and card shops provide to make the features of the game more clear

- Text styling overhaul in card shop
   - Added disclaimer in card shop above shopping cart to inform the user of cart's function
- Slight positioning adjustments to the elements in the game user's mushroom trade offer line in the mushroom exchange shop to stop elements from bleeding off screen except in extremely high quantities of mushrooms
- Changes to xButtons (menu exit buttons) in both card shop and collector card inventory menus to be larger and more pronounced via red text coloring
- Collector card inventory "card sell button" was slightly raised and changed to a more distinctive blue color. More ideas on how to best make the button more pronounced are needed
- Changed tint of mushrooms on log when being selected during harvesting to a lighter green color